### PR TITLE
[UNIONVMS-4464] Serialization in Arquillian

### DIFF
--- a/message-impl/src/test/java/eu/europa/ec/fisheries/uvms/movement/message/BuildMovementServiceTestDeployment.java
+++ b/message-impl/src/test/java/eu/europa/ec/fisheries/uvms/movement/message/BuildMovementServiceTestDeployment.java
@@ -21,16 +21,6 @@ public abstract class BuildMovementServiceTestDeployment {
                 .resolve()
                 .withTransitivity().asFile();
         testWar.addAsLibraries(files);
-        
-//        File[] files = Maven.configureResolver().loadPomFromFile("pom.xml")
-//                .resolve("eu.europa.ec.fisheries.uvms.movement:movement-model",
-//                         "eu.europa.ec.fisheries.uvms.movement:movement-domain",
-//                         "eu.europa.ec.fisheries.uvms.movement:movement-service",
-//                         "eu.europa.ec.fisheries.uvms:uvms-config",
-//                         "eu.europa.ec.fisheries.uvms.commons:uvms-commons-message",
-//                         "org.apache.activemq:activemq-client")
-//                .withTransitivity().asFile();
-//        testWar.addAsLibraries(files);
 
         testWar.addPackages(true, "eu.europa.ec.fisheries.uvms.movement.message");
         
@@ -52,8 +42,8 @@ public abstract class BuildMovementServiceTestDeployment {
 
         testWar.addClass(UnionVMSMock.class);
         testWar.addClass(SpatialModuleMock.class);
+        testWar.addClass(TestObjectMapperContextResolver.class);
 
         return testWar;
     }
-
 }

--- a/message-impl/src/test/java/eu/europa/ec/fisheries/uvms/movement/message/TestObjectMapperContextResolver.java
+++ b/message-impl/src/test/java/eu/europa/ec/fisheries/uvms/movement/message/TestObjectMapperContextResolver.java
@@ -1,0 +1,30 @@
+package eu.europa.ec.fisheries.uvms.movement.message;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * This is a copy of the {@code eu.europa.ec.fisheries.uvms.spatial.rest.util.ObjectMapperContextResolver}
+ * of the Spatial module, so that the configuration for serialization is the same in tests and in runtime.
+ */
+@Provider
+public class TestObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+	private final ObjectMapper mapper;
+
+	public TestObjectMapperContextResolver() {
+		mapper = new ObjectMapper();
+
+		mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+	}
+
+	@Override
+	public ObjectMapper getContext(Class<?> type) {
+		return mapper;
+	}
+}

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/movement/rest/BuildMovementRestDeployment.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/movement/rest/BuildMovementRestDeployment.java
@@ -39,10 +39,6 @@ public abstract class BuildMovementRestDeployment {
                 .withTransitivity().asFile();
         testWar.addAsLibraries(files);
         
-        /*testWar.addAsLibraries(Maven.configureResolver().loadPomFromFile("pom.xml")
-                //.resolve("eu.europa.ec.fisheries.uvms.movement:movement-service")
-                .withoutTransitivity().asFile());*/
-
         testWar.addPackages(true, "eu.europa.ec.fisheries.uvms.movement.rest");
 
         testWar.delete("/WEB-INF/web.xml");
@@ -65,6 +61,7 @@ public abstract class BuildMovementRestDeployment {
 
         testWar.addClass(UnionVMSMock.class);
         testWar.addClass(SpatialModuleMock.class);
+        testWar.addClass(TestObjectMapperContextResolver.class);
 
         return testWar;
     }
@@ -73,7 +70,7 @@ public abstract class BuildMovementRestDeployment {
 
         ObjectMapper objectMapper = new ObjectMapper();
         Client client = ClientBuilder.newClient();
-        client.register(new JacksonJaxbJsonProvider(objectMapper, JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS));
+//        client.register(new JacksonJaxbJsonProvider(objectMapper, JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS));
         return client.target("http://"+HOST+":"+REST_PORT+"/test/rest");
     }
 }

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/movement/rest/TestObjectMapperContextResolver.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/movement/rest/TestObjectMapperContextResolver.java
@@ -1,0 +1,30 @@
+package eu.europa.ec.fisheries.uvms.movement.rest;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * This is a copy of the {@code eu.europa.ec.fisheries.uvms.spatial.rest.util.ObjectMapperContextResolver}
+ * of the Spatial module, so that the configuration for serialization is the same in tests and in runtime.
+ */
+@Provider
+public class TestObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+	private final ObjectMapper mapper;
+
+	public TestObjectMapperContextResolver() {
+		mapper = new ObjectMapper();
+
+		mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+	}
+
+	@Override
+	public ObjectMapper getContext(Class<?> type) {
+		return mapper;
+	}
+}


### PR DESCRIPTION
Apply the configuration from Spatial/`ObjectMapperContextResolver` to the mock deployment of spatial for Arquillian, so that serialization works the same.