### PR TITLE
[UNIONVMS-4611] Manual subscriptions area criterion

### DIFF
--- a/message-impl/src/main/java/eu/europa/ec/fisheries/uvms/movement/message/consumer/bean/MovementMessageConsumerBean.java
+++ b/message-impl/src/main/java/eu/europa/ec/fisheries/uvms/movement/message/consumer/bean/MovementMessageConsumerBean.java
@@ -88,6 +88,9 @@ public class MovementMessageConsumerBean implements MessageListener {
                 case MOVEMENT_LIST_BY_AREA_TIME_INTERVAL:
                     movementEventBean.getMovementListByAreaAndTimeInterval(eventMessage);
                     break;
+                case FILTER_GUID_LIST_FOR_DATE_BY_AREA:
+                    movementEventBean.filterGuidListByDateAndAreas(eventMessage);
+                    break;
                 case GET_SEGMENT_BY_ID:
                 case GET_TRIP_BY_ID:
                 default:

--- a/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/exception/InvalidArgumentException.java
+++ b/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/exception/InvalidArgumentException.java
@@ -1,0 +1,19 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.movement.model.exception;
+
+public class InvalidArgumentException extends MovementModelRuntimeException{
+
+    public InvalidArgumentException(String message){
+        super(message,ErrorCode.ILLEGAL_ARGUMENT_ERROR);
+    }
+}

--- a/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/exception/MovementModelRuntimeException.java
+++ b/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/exception/MovementModelRuntimeException.java
@@ -3,7 +3,7 @@ package eu.europa.ec.fisheries.uvms.movement.model.exception;
 import eu.europa.ec.fisheries.schema.movement.common.v1.ExceptionType;
 
 /**
- * The MovementModelException wraps all checked standard Java runtime exception and enriches them with a custom error code.
+ * The MovementModelRuntimeException wraps all unchecked standard Java runtime exception and enriches them with a custom error code.
  * You can use this code to retrieve localized error messages from online documentation. (If implemented)
  *
  * @author Kasim Gul

--- a/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/mapper/JAXBMarshaller.java
+++ b/model/src/main/java/eu/europa/ec/fisheries/uvms/movement/model/mapper/JAXBMarshaller.java
@@ -78,7 +78,7 @@ public class JAXBMarshaller {
      * @throws
      * eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelException
      */
-    public static <R> R unmarshallTextMessage(TextMessage textMessage, Class clazz) throws MovementModelException {
+    public static <R> R unmarshallTextMessage(TextMessage textMessage, Class<R> clazz) throws MovementModelException {
         try {
             JAXBContext jc = contexts.get(clazz.getName());
             if (jc == null) {

--- a/model/src/main/resources/contract/Area.xsd
+++ b/model/src/main/resources/contract/Area.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:area="urn:area.movement.schema.fisheries.ec.europa.eu:v1" 
+<xsd:schema xmlns:area="urn:area.movement.schema.fisheries.ec.europa.eu:v1"
             targetNamespace="urn:area.movement.schema.fisheries.ec.europa.eu:v1"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:area.movement.schema.fisheries.ec.europa.eu:v1"
             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
             xmlns="http://schemas.xmlsoap.org/wsdl/">
 
@@ -9,6 +10,15 @@
         <xsd:sequence>
             <xsd:element name="areaName" type="xsd:string"/>
             <xsd:element name="areaId" type="xsd:long"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GuidListForAreaFilteringQuery">
+        <xsd:sequence>
+            <xsd:element name="guidList" type="xsd:string"  minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="startDate" type="xsd:date"/>
+            <xsd:element name="endDate" type="xsd:date"/>
+            <xsd:element name="areas" type="tns:AreaType"  minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/model/src/main/resources/contract/MovementModuleService.wsdl
+++ b/model/src/main/resources/contract/MovementModuleService.wsdl
@@ -4,6 +4,7 @@
              xmlns:search="urn:search.movement.schema.fisheries.ec.europa.eu:v1"
              xmlns:common="urn:common.movement.schema.fisheries.ec.europa.eu:v1"
              xmlns:movement="urn:movement.schema.fisheries.ec.europa.eu:v1"
+             xmlns:area="urn:area.movement.schema.fisheries.ec.europa.eu:v1"
              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
              xmlns="http://schemas.xmlsoap.org/wsdl/">
@@ -14,7 +15,8 @@
             <xsd:import namespace="urn:common.movement.schema.fisheries.ec.europa.eu:v1" schemaLocation="MovementCommon.xsd"/>
             <xsd:import namespace="urn:search.movement.schema.fisheries.ec.europa.eu:v1" schemaLocation="MovementSearch.xsd"/>
             <xsd:import namespace="urn:movement.schema.fisheries.ec.europa.eu:v1" schemaLocation="Movement.xsd"/>
-            
+            <xsd:import namespace="urn:area.movement.schema.fisheries.ec.europa.eu:v1" schemaLocation="Area.xsd"/>
+
             <!-- Mobile Terminal Base Request -->
             <xsd:simpleType name="MovementModuleMethod">
                 <xsd:restriction base="xsd:string">
@@ -26,6 +28,7 @@
                     <xsd:enumeration value="GET_SEGMENT_BY_ID"/>
                     <xsd:enumeration value="PING"/>
                     <xsd:enumeration value="MOVEMENT_LIST_BY_AREA_TIME_INTERVAL"/>
+                    <xsd:enumeration value="FILTER_GUID_LIST_FOR_DATE_BY_AREA"/>
                 </xsd:restriction>
             </xsd:simpleType>
             
@@ -162,7 +165,28 @@
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>
-            
+
+            <!-- filter guid list by area and date -->
+            <xsd:element name="FilterGuidListByAreaAndDateRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="module:MovementBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="query" type="area:GuidListForAreaFilteringQuery"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="FilterGuidListByAreaAndDateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="filteredList" type="xsd:string"  minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
             <!-- Ping -->
             <xsd:element name="pingRequest">
                 <xsd:complexType>
@@ -272,6 +296,13 @@
         <part name="body" element="module:getMovementListByAreaAndTimeIntervalResponse"/>
     </message>
 
+    <message name="FilterGuidListByAreaAndDateRequestMessage">
+        <part name="body" element="module:FilterGuidListByAreaAndDateRequest"/>
+    </message>
+    <message name="FilterGuidListByAreaAndDateResponseMessage">
+        <part name="body" element="module:FilterGuidListByAreaAndDateResponse"/>
+    </message>
+
     <message name="ProcessedMovementAck">
         <part name="body" element="module:ProcessedMovementAck"/>
     </message>
@@ -331,6 +362,11 @@
             <fault name="MovementException" message="module:MovementException"/>
         </operation>
 
+        <operation name="FilterGuidListByAreaAndDateOperation">
+            <input message="module:FilterGuidListByAreaAndDateRequestMessage"/>
+            <output message="module:FilterGuidListByAreaAndDateResponseMessage"/>
+            <fault name="MovementException" message="module:MovementException"/>
+        </operation>
     </portType>
 
     <binding name="MovementModuleSoapBinding" type="module:MovementModulePortType">
@@ -438,6 +474,17 @@
             </fault>
         </operation>
 
+        <operation name="FilterGuidListByAreaAndDateOperation">
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="MovementException">
+                <soap:fault name="MovementException" use="literal"/>
+            </fault>
+        </operation>
     </binding>
 
     <service name="MovementModuleService">

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementFiltererBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementFiltererBean.java
@@ -1,0 +1,51 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.movement.service.bean;
+
+import eu.europa.ec.fisheries.schema.movement.area.v1.AreaType;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.InvalidArgumentException;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelRuntimeException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class MovementFiltererBean {
+
+    @Inject
+    private MovementService movementService;
+
+    public List<String> filterGuidListForPeriodAndAreaTypesByArea(List<String> guidList, Date startDate, Date endDate, List<AreaType> areaTypes) throws MovementModelRuntimeException {
+        checkArguments(guidList, startDate, endDate, areaTypes);
+
+        List<Long> movementAreaIds = movementService.findMovementAreaIdsByAreaRemoteIdAndNameList(areaTypes);
+        if (movementAreaIds == null || movementAreaIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return guidList.stream()
+                .filter(connectId -> movementService.checkMovementExistence(connectId,startDate,endDate,movementAreaIds))
+                .collect(Collectors.toList());
+    }
+
+    private void checkArguments(List<String> guidList, Date startDate, Date endDate, List<AreaType> areaTypes) {
+        if(guidList == null || guidList.isEmpty()) throw new InvalidArgumentException("No Guid list to filter");
+        if(startDate == null) throw new InvalidArgumentException("No start date provided/or invalid syntax, try UTC");
+        if(endDate == null) throw new InvalidArgumentException("No end date provided/or invalid syntax, try UTC");
+        if(startDate.toInstant().isAfter(endDate.toInstant())) throw new InvalidArgumentException("Start date cannot be after end date");
+        if(areaTypes == null || areaTypes.isEmpty()) throw new InvalidArgumentException("Area type list was empty");
+    }
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementService.java
@@ -14,6 +14,7 @@ package eu.europa.ec.fisheries.uvms.movement.service.bean;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,8 @@ import javax.ejb.Stateless;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import eu.europa.ec.fisheries.schema.movement.area.v1.AreaType;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import eu.europa.ec.fisheries.schema.movement.search.v1.ListCriteria;
@@ -451,5 +454,13 @@ public class MovementService {
             }
         }
         return true;
+    }
+
+    public List<Long> findMovementAreaIdsByAreaRemoteIdAndNameList(List<AreaType> areaTypes)  {
+        return dao.findMovementAreaIdsByAreaRemoteIdAndNameList(areaTypes);
+    }
+
+    public boolean checkMovementExistence(String connectId, Date startDate, Date endDate, List<Long> movementAreaIds) throws MovementModelRuntimeException {
+        return dao.checkMovementExistence(connectId,startDate,endDate,movementAreaIds);
     }
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/entity/Movement.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/entity/Movement.java
@@ -76,6 +76,8 @@ import org.hibernate.annotations.Type;
     @NamedQuery(name = Movement.FIND_EXISTING_DATE, query = "SELECT m FROM Movement m WHERE m.movementConnect.value = :id AND m.timestamp = :date AND m.duplicate = false AND m.processed = true"),
     @NamedQuery(name = Movement.NR_OF_MOVEMENTS_FOR_ASSET_IN_TIMESPAN, query = "SELECT COUNT (m) FROM Movement m WHERE m.timestamp BETWEEN :fromDate AND :toDate AND m.movementConnect.value = :asset AND m.duplicate = false"),
     @NamedQuery(name = MicroMovementDto.FIND_ALL_AFTER_DATE, query = "SELECT new eu.europa.ec.fisheries.uvms.movement.service.dto.MicroMovementDto(m.location, m.heading, m.guid, m.movementConnect, m.timestamp, m.speed) FROM Movement m WHERE m.timestamp > :date AND m.duplicate = false"),
+    @NamedQuery(name = Movement.FIND_BY_CONNECTID_FOR_AREAS_IN_A_PERIOD , query = "SELECT m FROM Movement m WHERE m.movementConnect.value = :connectId AND m.timestamp >= :startDate AND m.timestamp < :endDate "+
+                                                                                  "AND EXISTS (SELECT ma.movareaId FROM Movementarea ma WHERE ma.movareaMoveId = m AND ma.movareaAreaId.areaId IN :movementAreaIds) ")
 })
 @DynamicUpdate
 @DynamicInsert
@@ -101,7 +103,7 @@ public class Movement implements Serializable, Comparable<Movement> {
     public static final String LIST_BY_AREA_TIME_INTERVAL = "Movement.findMovementByAreaAndTimestampInterval";
     public static final String FIND_EXISTING_DATE = "Movement.findExistingDate";
     public static final String NR_OF_MOVEMENTS_FOR_ASSET_IN_TIMESPAN = "Movement.nrOfMovementsForAssetInTimespan";
-
+    public static final String FIND_BY_CONNECTID_FOR_AREAS_IN_A_PERIOD = "Movement.findMovementByConnectIdForAreasInAPeriod";
     
     private static final long serialVersionUID = 1L;
 

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/MockData.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/MockData.java
@@ -43,9 +43,11 @@ public class MockData {
     }
 
     public static AreaType createAreaType() {
+        return createAreaType("TestAreaType");
+    }
+    public static AreaType createAreaType(String name) {
         AreaType areaType = new AreaType();
-        String input = "TestAreaType";
-        areaType.setName(input);
+        areaType.setName(name);
         areaType.setUpdatedTime(Instant.now());
         areaType.setUpdatedUser("TestUser");
         return areaType;
@@ -64,16 +66,20 @@ public class MockData {
     }
     
     public static Area createArea(AreaType areaType) {
+        return createArea(areaType,"TestRemoteId");
+    }
+
+    public static Area createArea(AreaType areaType,String remoteId) {
         Area area = new Area();
         area.setAreaName("TestArea");
         area.setAreaCode("AreaCode" + MovementHelpers.getRandomIntegers(10));
-        area.setRemoteId("TestRemoteId");
+        area.setRemoteId(remoteId);
         area.setAreaUpdattim(Instant.now());
         area.setAreaUpuser("TestUser");
         area.setAreaType(areaType);
         return area;
     }
-    
+
     public static Movementarea getMovementArea(Area area, Movement movement) {
         Movementarea movementArea = new Movementarea();
         movementArea.setMovareaAreaId(area);

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementDaoBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementDaoBeanTest.java
@@ -1,15 +1,27 @@
 package eu.europa.ec.fisheries.uvms.movement.service.bean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import javax.ejb.EJB;
 import javax.ejb.EJBTransactionRolledbackException;
 import javax.inject.Inject;
+
+import eu.europa.ec.fisheries.uvms.movement.service.MockData;
+import eu.europa.ec.fisheries.uvms.movement.service.dao.AreaDao;
+import eu.europa.ec.fisheries.uvms.movement.service.entity.area.Area;
+import eu.europa.ec.fisheries.uvms.movement.service.entity.area.AreaType;
+import eu.europa.ec.fisheries.uvms.movement.service.entity.area.Movementarea;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,33 +35,36 @@ import eu.europa.ec.fisheries.uvms.movement.service.exception.MovementServiceExc
 
 @RunWith(Arquillian.class)
 public class MovementDaoBeanTest extends TransactionalTests {
-	
+
 	@EJB
-    private MovementBatchModelBean movementBatchModelBean;
-	
+	private MovementBatchModelBean movementBatchModelBean;
+
 	@Inject
 	private IncomingMovementBean incomingMovementBean;
 
-    @EJB
-    private MovementDao movementDao;
+	@EJB
+	private MovementDao movementDao;
+
+	@EJB
+	private AreaDao areaDao;
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
-	
+
 	@Test
 	public void testGetMovementsByGUID() throws MovementServiceException {
 		Movement output = movementDao.getMovementByGUID(UUID.randomUUID().toString());
 		assertNull(output);
-		
+
 		String connectId = UUID.randomUUID().toString();
 		MovementHelpers movementHelpers = new MovementHelpers(movementBatchModelBean);
 		Movement move = movementHelpers.createMovement(20D, 20D, connectId, "TEST", Instant.now());
-		
+
 		output = movementDao.getMovementByGUID(move.getGuid());
 		System.out.println(output);
 		assertEquals(move.getGuid(), output.getGuid());
 	}
-	
+
 	@Test
 	public void testGetLatestMovementByConnectIdList() throws MovementServiceException {
 		String connectID = UUID.randomUUID().toString();
@@ -58,37 +73,37 @@ public class MovementDaoBeanTest extends TransactionalTests {
 		Movement move1 = movementHelpers.createMovement(20D, 20D, connectID, "TEST", Instant.now());
 		Movement move2 = movementHelpers.createMovement(21D, 21D, connectID, "TEST", Instant.now().plusSeconds(1));
 		Movement move3 = movementHelpers.createMovement(22D, 22D, connectID2, "TEST", Instant.now().plusSeconds(2));
-		
+
 		incomingMovementBean.processMovement(move1);
 		incomingMovementBean.processMovement(move2);
 		incomingMovementBean.processMovement(move3);
-		
+
 		List<String> input = new ArrayList<>();
 		input.add(connectID);
 		List<Movement> output = movementDao.getLatestMovementsByConnectIdList(input);
 		assertEquals(1, output.size());
-		
+
 		//add the same id again just to see if we get duplicates
 		input.add(connectID);
 		output = movementDao.getLatestMovementsByConnectIdList(input);
 		assertEquals(1, output.size());
 		assertEquals(move2.getGuid(), output.get(0).getGuid());
-		
+
 		input.add(connectID2);
 		output = movementDao.getLatestMovementsByConnectIdList(input);
 		assertEquals(2, output.size());
-		
+
 		//null as input should return an empty set
 		output = movementDao.getLatestMovementsByConnectIdList(null);
 		assertTrue(output.isEmpty());
-			
+
 		//random input should result in an empty set
 		input = new ArrayList<>();
 		input.add(UUID.randomUUID().toString());
 		output = movementDao.getLatestMovementsByConnectIdList(input);
 		assertTrue(output.isEmpty());
 	}
-	
+
 	@Test
 	public void testGetLatestMovementsByConnectID() throws MovementServiceException {
 		String connectID = UUID.randomUUID().toString();
@@ -97,17 +112,17 @@ public class MovementDaoBeanTest extends TransactionalTests {
 		Movement move2 = movementHelpers.createMovement(21D, 21D, connectID, "TEST", Instant.now().plusSeconds(1));
 		Movement move3 = movementHelpers.createMovement(22D, 22D, connectID, "TEST42", Instant.now().plusSeconds(2));
 
-        incomingMovementBean.processMovement(move1);
-        incomingMovementBean.processMovement(move2);
-        incomingMovementBean.processMovement(move3);
-		
+		incomingMovementBean.processMovement(move1);
+		incomingMovementBean.processMovement(move2);
+		incomingMovementBean.processMovement(move3);
+
 		List<Movement> output = movementDao.getLatestMovementsByConnectId(connectID, 1);
 		assertEquals(1, output.size());
 		assertEquals(move3.getGuid(), output.get(0).getGuid());
-		
+
 		output = movementDao.getLatestMovementsByConnectId(connectID, 3);
 		assertEquals(3, output.size());
-		
+
 //		try {
 //			output = movementDao.getLatestMovementsByConnectId(connectID, -3);
 //			fail("negative value as input should result in an exception");
@@ -116,7 +131,7 @@ public class MovementDaoBeanTest extends TransactionalTests {
 //		}
 		output = movementDao.getLatestMovementsByConnectId(UUID.randomUUID().toString(), 1);
 		assertTrue(output.isEmpty());
-		
+
 		//funnily enough this is only true if you are only expecting 1 result.......
 		output = movementDao.getLatestMovementsByConnectId(UUID.randomUUID().toString(), 2);
 		assertTrue(output.isEmpty());
@@ -136,15 +151,122 @@ public class MovementDaoBeanTest extends TransactionalTests {
 		incomingMovementBean.processMovement(move1);
 		incomingMovementBean.processMovement(move2);
 		incomingMovementBean.processMovement(move3);
-		
+
 		List<Movement> output = movementDao.getLatestMovementsByConnectId(connectID, 1);
 		assertEquals(1, output.size());
 		assertEquals(move3.getGuid(), output.get(0).getGuid());
 
 		movementDao.getLatestMovementsByConnectId(connectID, -3);
 	}
-	
-	
+
+	@Test
+	public void testFindMovementAreaIdsByAreaRemoteIdAndNameList() {
+
+		final String AREA_TYPE_1 = "AreaType1";
+		final String AREA_TYPE_2 = "AreaType2";
+		final long REMOTE_ID_10 = 10;
+		final long REMOTE_ID_20 = 20;
+		final long REMOTE_ID_30 = 30;
+		AreaType areaType = MockData.createAreaType(AREA_TYPE_1);
+		AreaType areaType2 = MockData.createAreaType(AREA_TYPE_2);
+		Area areaA = areaDao.createMovementArea(MockData.createArea(areaType,String.valueOf(REMOTE_ID_10)));
+		Area areaB = areaDao.createMovementArea(MockData.createArea(areaType,String.valueOf(REMOTE_ID_10)));
+		Area areaC = areaDao.createMovementArea(MockData.createArea(areaType2,String.valueOf(REMOTE_ID_30)));
+
+		String connectId = UUID.randomUUID().toString();
+		Instant timestamp = Instant.now();
+		Movement firstMovement = MockData.createMovement(0d, 1d, connectId, 0, "TEST");
+		firstMovement.setTimestamp(timestamp);
+		Movementarea movementArea1 = MockData.getMovementArea(areaA, firstMovement);
+		firstMovement.setMovementareaList(Arrays.asList(movementArea1));
+		movementBatchModelBean.createMovement(firstMovement);
+
+
+		Movement secondMovement = MockData.createMovement(1d, 1d, connectId, 0, "TEST");
+		secondMovement.setTimestamp(timestamp.plusSeconds(10));
+		Movementarea movementArea2 = MockData.getMovementArea(areaB, secondMovement);
+		secondMovement.setMovementareaList(Arrays.asList(movementArea2));
+		movementBatchModelBean.createMovement(secondMovement);
+
+		Movement thirdMovement = MockData.createMovement(1d, 2d, connectId, 0, "TEST");
+		thirdMovement.setTimestamp(timestamp.plusSeconds(20));
+		Movementarea movementArea3 = MockData.getMovementArea(areaC, thirdMovement);
+		thirdMovement.setMovementareaList(Arrays.asList(movementArea3));
+		movementBatchModelBean.createMovement(thirdMovement);
+
+		List<eu.europa.ec.fisheries.schema.movement.area.v1.AreaType> areaTypes = new ArrayList<>();
+		eu.europa.ec.fisheries.schema.movement.area.v1.AreaType areaType11 = new eu.europa.ec.fisheries.schema.movement.area.v1.AreaType();
+		areaType11.setAreaName(AREA_TYPE_1);
+		areaType11.setAreaId(REMOTE_ID_10);
+
+		eu.europa.ec.fisheries.schema.movement.area.v1.AreaType areaType22 = new eu.europa.ec.fisheries.schema.movement.area.v1.AreaType();
+		areaType22.setAreaName(AREA_TYPE_2);
+		areaType22.setAreaId(REMOTE_ID_20);
+		areaTypes.add(areaType11);
+		areaTypes.add(areaType22);
+
+		List<Long> maIds = movementDao.findMovementAreaIdsByAreaRemoteIdAndNameList(areaTypes);
+		assertNotNull("MovementArea ids list wasn't suppose to be null", maIds);
+		assertEquals("MovementArea ids list size wasn't as expected" , maIds.size(),2);
+	}
+
+	@Test
+	public void testCheckMovementExistence() {
+
+		final LocalDate todayLD = LocalDate.now();
+		final Instant twoMonthsAgo = todayLD.minusMonths(2).atStartOfDay(ZoneId.systemDefault()).toInstant();
+		final Instant lastMonth = todayLD.minusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+		final Instant today = todayLD.atStartOfDay(ZoneId.systemDefault()).toInstant();
+		final Instant nextMonth = todayLD.plusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+		final String AREA_TYPE_1 = "AreaType1";
+		final String AREA_TYPE_2 = "AreaType2";
+		final long REMOTE_ID_10 = 10;
+		final long REMOTE_ID_20 = 20;
+		AreaType areaType = MockData.createAreaType(AREA_TYPE_1);
+		AreaType areaType2 = MockData.createAreaType(AREA_TYPE_2);
+		Area areaA = areaDao.createMovementArea(MockData.createArea(areaType,String.valueOf(REMOTE_ID_10)));
+		Area areaB = areaDao.createMovementArea(MockData.createArea(areaType,String.valueOf(REMOTE_ID_10)));
+		Area areaC = areaDao.createMovementArea(MockData.createArea(areaType2,String.valueOf(REMOTE_ID_20)));
+
+		String connectId = UUID.randomUUID().toString();
+		Movement firstMovement = MockData.createMovement(0d, 1d, connectId, 0, "TEST");
+		firstMovement.setTimestamp(today);
+		Movementarea movementArea1 = MockData.getMovementArea(areaA, firstMovement);
+		firstMovement.setMovementareaList(Arrays.asList(movementArea1));
+		movementBatchModelBean.createMovement(firstMovement);
+
+		Movement secondMovement = MockData.createMovement(1d, 1d, connectId, 0, "TEST");
+		secondMovement.setTimestamp(lastMonth);
+		Movementarea movementArea2 = MockData.getMovementArea(areaB, secondMovement);
+		secondMovement.setMovementareaList(Arrays.asList(movementArea2));
+		movementBatchModelBean.createMovement(secondMovement);
+
+		Movement thirdMovement = MockData.createMovement(1d, 2d, connectId, 0, "TEST");
+		thirdMovement.setTimestamp(nextMonth);
+		Movementarea movementArea3 = MockData.getMovementArea(areaC, thirdMovement);
+		thirdMovement.setMovementareaList(Arrays.asList(movementArea3));
+		movementBatchModelBean.createMovement(thirdMovement);
+
+		List<eu.europa.ec.fisheries.schema.movement.area.v1.AreaType> areaTypes = new ArrayList<>();
+		eu.europa.ec.fisheries.schema.movement.area.v1.AreaType areaType11 = new eu.europa.ec.fisheries.schema.movement.area.v1.AreaType();
+		areaType11.setAreaName(AREA_TYPE_1);
+		areaType11.setAreaId(REMOTE_ID_10);
+
+		eu.europa.ec.fisheries.schema.movement.area.v1.AreaType areaType22 = new eu.europa.ec.fisheries.schema.movement.area.v1.AreaType();
+		areaType22.setAreaName(AREA_TYPE_2);
+		areaType22.setAreaId(REMOTE_ID_20);
+		areaTypes.add(areaType11);
+		areaTypes.add(areaType22);
+
+		List<Long> maIds = movementDao.findMovementAreaIdsByAreaRemoteIdAndNameList(areaTypes);
+
+		boolean result1 = movementDao.checkMovementExistence(connectId, Date.from(lastMonth),Date.from(nextMonth),maIds);
+		assertTrue("Movement should be found",result1);
+		boolean result2 = movementDao.checkMovementExistence(connectId, Date.from(twoMonthsAgo),Date.from(lastMonth),maIds);
+		assertFalse("Where did that movement came from?",result2);
+	}
+
 	@Test
 	public void testIsDateAlreadyInserted() {
 		//only testing the no result part since the rest of teh function is tested elsewhere


### PR DESCRIPTION
Added request, response elements in MovementModuleService.wsdl, message and operation elements for generating test xml through soap ui, and inner GuidListForAreaFilteringQuery element on Area.xsd.
Added MovementFiltererBean that filters requested list of guid per start date,end date and areas (areaId and area type name). Returns the filtered list. Initially fetches the Area id list referenced from Movementarea and if there are such elements check for Movement existence for the rest parameters.
Added test cases for the MovementDao methods.

Signed-off-by: lsotiriadis <leontion.sotiriadis@sword-group.com>