### PR TITLE
a position that lacked positionTime but where the asset has previous …

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementCreateBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/movement/service/bean/MovementCreateBean.java
@@ -123,7 +123,8 @@ public class MovementCreateBean {
     }
 
     private Movement getPreviousVms(IncomingMovement movement, MovementConnect movementConnect) {
-        if (MovementSourceType.AIS.value().equals(movement.getMovementSourceType())) {
+        if (MovementSourceType.AIS.value().equals(movement.getMovementSourceType())
+                || movement.getPositionTime() == null) {
             return null;
         }
         Movement currentLatestVMS = movementConnect.getLatestVMS();

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/message/consumer/bean/SanityRulesTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/movement/service/message/consumer/bean/SanityRulesTest.java
@@ -158,6 +158,7 @@ public class SanityRulesTest extends BuildMovementServiceTestDeployment {
 
         assertThat(response.getMovementRefType().getType(), is(MovementRefTypeType.ALARM));
     }
+
     @Test
     @OperateOnDeployment("movementservice")
     public void setMovementReportMissingPositionTimeSanityRuleTest() throws Exception {
@@ -166,6 +167,30 @@ public class SanityRulesTest extends BuildMovementServiceTestDeployment {
         incomingMovement.setAssetHistoryId(null);
         incomingMovement.setPositionTime(null);
         ProcessedMovementResponse response = sendIncomingMovementAndReturnAlarmResponse(incomingMovement);
+
+        assertThat(response.getMovementRefType().getType(), is(MovementRefTypeType.ALARM));
+    }
+
+    @Test
+    @OperateOnDeployment("movementservice")
+    public void setMovementReportMissingPositionTimeWithPreviousMovement() throws Exception {
+
+        UUID id = UUID.randomUUID();
+        IncomingMovement incomingMovement = MovementTestHelper.createIncomingMovementType();
+        incomingMovement.setAssetGuid(null);
+        incomingMovement.setAssetHistoryId(id.toString());
+        incomingMovement.setAssetIRCS("TestIrcs:" + id);
+        ProcessedMovementResponse response = sendIncomingMovementAndReturnAlarmResponse(incomingMovement);
+
+        assertThat(response.getMovementRefType().getType(), is(MovementRefTypeType.MOVEMENT));
+
+
+        IncomingMovement incomingMovement2 = MovementTestHelper.createIncomingMovementType();
+        incomingMovement2.setAssetGuid(null);
+        incomingMovement2.setAssetHistoryId(null);
+        incomingMovement2.setAssetIRCS("TestIrcs:" + id);
+        incomingMovement2.setPositionTime(null);
+        response = sendIncomingMovementAndReturnAlarmResponse(incomingMovement2);
 
         assertThat(response.getMovementRefType().getType(), is(MovementRefTypeType.ALARM));
     }


### PR DESCRIPTION
…vms positions resulted in a null-pointer since it was used before sanity check. Now fixed with test.